### PR TITLE
Enable SSL support

### DIFF
--- a/client/data/config.json-dist
+++ b/client/data/config.json-dist
@@ -1,5 +1,6 @@
 {
   "ip": "127.0.0.1",
   "port": 1800,
+  "ssl": false,
   "version": 2
 }

--- a/client/js/network/socket.js
+++ b/client/js/network/socket.js
@@ -20,7 +20,8 @@ define(['./packets', './messages'], function(Packets, Messages) {
 
         connect: function() {
             var self = this,
-                url = 'ws://' + self.config.ip + ':' + self.config.port;
+                protocol = ((self.config.ssl) ? 'wss' : 'ws'),
+                url = protocol + '://' + self.config.ip + ':' + self.config.port;
 
             self.connection = null;
 


### PR DESCRIPTION
I tried running Tap Tap Adventure using SSL. However the client assumes that you will be using plain websockets rather than secure websockets and fails to connect to the server.

This PR adds an extra config option (which defaults to `false`) to enable SSL support. The option simply switches the websocket protocol between `ws` and `wss`.